### PR TITLE
Update RobotID for 2024 Robot

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -57,6 +57,7 @@ public class RobotContainer {
 
       default:
       case SwerveCompetition:
+      case Vertigo:
       case SwerveTest:
         vision = new Vision(VisionConstants.CAMERAS);
 

--- a/src/main/java/frc/robot/RobotId.java
+++ b/src/main/java/frc/robot/RobotId.java
@@ -11,7 +11,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
  */
 public enum RobotId {
     Default,
-    SwerveCompetition, SwerveTest,
+    SwerveCompetition, Vertigo, SwerveTest,
     ClassBot1, ClassBot2, ClassBot3, ClassBot4,
     TestBed1, TestBed2;
 

--- a/src/main/java/frc/robot/constants/swerve/DriveConstants.java
+++ b/src/main/java/frc/robot/constants/swerve/DriveConstants.java
@@ -144,7 +144,23 @@ public class DriveConstants {
      * Updates the constants if the RobotId is not the competition robot.
      */
     public static void update(RobotId robotId) {
-        if (robotId == RobotId.SwerveTest) {
+        if (robotId == RobotId.Vertigo) {
+            kTrackWidth = Units.inchesToMeters(20.75);//22.75 swerve bot, 20.75 comp bot
+            
+            kPigeon = 13;
+
+            kSteerOffsetFrontLeft = 4.185;//0.058291152119637;//-3.060285486280918+Math.PI;
+
+            kSteerOffsetFrontRight = 101.519+90;//-2.994324445724487;//-3.001994334161282;
+
+            kSteerOffsetBackLeft = 38.997+180;//-2.540267050266266;//0.650406539440155+Math.PI;
+
+            kSteerOffsetBackRight = 242.847-90;//2.626169800758362;//2.771897681057453;
+
+            // CAN
+            kDriveMotorCAN = Constants.CANIVORE_CAN;
+        
+        } else if (robotId == RobotId.SwerveTest) {
 
             kTrackWidth = Units.inchesToMeters(22.75); //22.75 swerve bot, 20.75 comp bot
 


### PR DESCRIPTION
<!--
PLEASE CHECK THE PR GUIDLINES:
 https://docs.google.com/document/d/14ZIhQRlUPK0wl5_AmM80N2D2KJUd6k_7I6isLS89YKU/edit
These are the things we are going to be checking your PR has, if it doesn't your PR will be rejected!
-->

## Overview
<!-- A general very short overview of the PR -->
This PR will update RobotID to include the new robot. SwerveCompetition will be used for the 2024 robot and Vertigo will be the ID for Vertigo. SwerveTest and the testbed IDs are still the same. The default offsets are for the SwerveCompetition robot. If the RobotID is SwerveTest or Vertigo, the correct offsets for those robots will be set. 


## Design Doc
<!-- Link your approved design doc. We will be checking that the code fits everything in the design doc. If the PR is only meant to address part of the deisgn doc, note here what is not yet implemented from the Design Doc -->
No design doc. 

## Tests Ran
<!-- Make sure the code builds and that the code runs in the sim. -->
Code builds and appears to work fine in the sim. 

## Additional Notes
<!-- Anything else that will help the reviewer understand your PR -->
Before using Vertigo after this fix, the RobotID must be set to Vertigo in OutlineViewer. 